### PR TITLE
Make `rayon` truly optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ itertools = "^0.9.0"
 zopfli = "^0.4.0"
 miniz_oxide = "0.4"
 rgb = "0.8.25"
-indexmap = { version = "1.6.0", features = ["rayon"] }
+indexmap = "1.6.0"
 libdeflater = "0.5.0"
 log = "0.4.11"
 stderrlog = { version = "0.5.0", optional = true }
@@ -72,7 +72,7 @@ binary = [
     "stderrlog",
 ]
 default = ["binary", "parallel"]
-parallel = ["rayon"]
+parallel = ["rayon", "indexmap/rayon"]
 
 [lib]
 name = "oxipng"


### PR DESCRIPTION
This reduces the amount of dependencies of a project that directly depends only on `oxipng` by 26 (with `default-features = false`).